### PR TITLE
Update dependencies

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^24.0.1",
     "@types/supertest": "^6.0.3",
     "eslint": "^9.29.0",
-    "jest": "^30.0.0",
+    "jest": "^29.7.0",
     "nodemon": "^3.1.10",
     "supertest": "^7.1.1",
     "ts-jest": "^29.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",


### PR DESCRIPTION
## Summary
- set backend jest version to ^29.7.0
- set frontend react/react-dom versions to ^18.2.0
- attempted to update package-locks via `npm install`, but registry access was blocked

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68508617aeb48333950ac44c82e2c203