### PR TITLE
Configure backend build output path

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "dev": "nodemon --config nodemon.json",
-    "build": "tsc",
+    "build": "rm -rf dist && tsc",
     "start": "node dist/app.js",
     "test": "jest"
   },

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -27,7 +27,8 @@
 
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
-    // "rootDir": "./src",                                  /* Specify the root folder within your source files. */
+    "rootDir": "./src",
+    "outDir": "./dist",
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */


### PR DESCRIPTION
## Summary
- emit compiled files to `dist` from `src`
- wipe `dist` before building

## Testing
- `npm run build` *(fails: Cannot find module 'express')*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685087a238848333a75e8903d43ed191