### PR TITLE
Add prerequisite npm install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ Este repositorio contiene una aplicación con un backend en Express y un fronten
 
 ## Desarrollo
 
-1. Instala las dependencias de cada proyecto:
+1. **Prerequisito:** instala las dependencias de cada proyecto:
 
    ```bash
    cd backend && npm install
    cd ../frontend && npm install
    ```
+
+   Podrás ejecutar binarios locales con `npx` cuando sea necesario.
 
 2. Copia `backend/.env.example` a `backend/.env` y proporciona valores para
    `DATABASE_URL`, `PORT` y `JWT_SECRET`. Opcionalmente ejecuta:


### PR DESCRIPTION
## Summary
- instruct to run `npm install` in both `backend` and `frontend`
- mention using `npx` for local tools

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68508db4b768833394f4e8cc3d717699